### PR TITLE
Implement `ReadSeek` for every type that implements `Read + Seek`

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -28,8 +28,7 @@ use pyo3::prelude::*;
 /// Trait representing a type that can be used to read and seek.
 pub trait ReadSeek: Read + Seek {}
 
-impl ReadSeek for std::fs::File {}
-impl<T: ReadSeek> ReadSeek for std::io::BufReader<T> {}
+impl<T: Read + Seek> ReadSeek for T {}
 
 /// Struct representing a wav file.
 /// The struct contains a boxed reader and the header information of the wav file.


### PR DESCRIPTION
Hi Jack! This is my first ever pull request that I am making. 

I propose that every type that implements `Read + Seek` should implement `ReadSeek`. 

I came across this need while trying to use your library on a scenario that I want to deal with. In my case, my wav-files are very large, thus I want them to be mmapped. 

This is the code that I wanted to write:

```rust
use std::error::Error;
use std::fs::File; 
use std::io::{Read, Cursor, BufReader, Seek}; 

use memmap2::Mmap; 
use wavers::{Wav, ReadSeek}; 


fn type_check_seek(t: impl Seek) {}
fn type_check_read(t: impl Read) {}
fn type_check_readseek(t: impl ReadSeek) {}

/* Unable to implement this, due to foreign trait + type policy
impl<T: ReadSeek> ReadSeek for Cursor<T> {
    :(
}
*/

fn test_read() -> Result<(), Box<dyn Error>> {
    
    let file = File::open("test.waw")?; 
    let data = unsafe {
        Mmap::map(&file)?
    };

    let c = BufReader::new(Cursor::new(data));
    type_check_seek(c);
    type_check_read(c);
    type_check_readseek(c); // Does not work... Complitation error, due to BufReader<Cursor<T>> not implementing ReadSeek

    //let stream = BufReader::new(Cursor::new(data.as_ref()));
    //let wav = Wav::new(Box::new(stream));

    Ok(())

}
```
but I couldnt use your library, even though my cursor and bufreader seemingly implements everything needed, namely `Read` and `Seek`.

I have run the tests you have provided, and they all pass, and I am considering adding another test case representing my usecase. What do you think?  

Best! 
Daniel