### PR TITLE
Make sub-modules public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,13 +147,15 @@
 //! To check out the benchmarks head on over to the benchmarks wiki page on the WaveRs <a href=https://github.com/jmg049/wavers/wiki/Benchmarks>GitHub</a>.
 //! Benchmarks were conducted on the reading and writing functionality of WaveRs and compared to the ``hound`` crate.
 //!
-mod chunks;
-mod conversion;
-mod core;
-mod error;
-mod header;
-mod iter;
-mod wav_type;
+pub mod chunks;
+pub mod conversion;
+pub mod core;
+
+pub mod error;
+pub mod header;
+
+pub mod iter;
+pub mod wav_type;
 
 use std::fmt::{self, Display};
 use std::fs;


### PR DESCRIPTION
This solves issue #20, making links to internal structs public.

![Screenshot from 2024-07-30 09-27-42](https://github.com/user-attachments/assets/35365181-f0d6-4821-bcea-8b484d972d03)
