### PR TITLE
bump ndarray version and fix Cargo.toml formatting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,12 +21,12 @@ bytemuck = "1.13.1"
 paste = "1.0.14"
 thiserror = "1.0.48"
 num-traits = "0.2.16"
-ndarray = { version = "0.15.6", optional = true }
+ndarray = { version = "0.16.1", optional = true }
 pyo3 = { version = "0.21.2", features = ["extension-module"], optional = true }
 numpy = { version = "0.21.0", optional = true }
 colored = { version = "2.1.0", optional = true }
-rubato = {version="0.15.0", optional = true}
-i24 = {version="1.0.1", default-features = false}
+rubato = { version = "0.15.0", optional = true }
+i24 = { version = "1.0.1", default-features = false }
 log = { version = "0.4.22", optional = true }
 
 


### PR DESCRIPTION
Nothing special, I just need to use the newest ndarray version and with 0.16.0 there was a breaking change, so all old crates are not compatible anymore.